### PR TITLE
Update docker compose file location

### DIFF
--- a/docs/developer/docker.md
+++ b/docs/developer/docker.md
@@ -48,7 +48,7 @@ Add the following line at the end of the hosts file to make the invoiceshelf.tes
 To spin up the Docker environment, run:
 
 ```bash
-docker compose -f .dev/docker-compose.mysql.yml up --build
+docker compose -f docker/development/docker-compose.mysql.yml up --build
 ```
 
 Once the environment is up and running you have the following containers:


### PR DESCRIPTION
Currently, the documentation calls for the following docker compose directory:
`.dev/docker-compose.mysql.yml`

Updating the link following commit [23f6b18](https://github.com/InvoiceShelf/InvoiceShelf/commit/23f6b1877fc38bc55c3e221bbd29bfb7f80d51ed) to:
`docker/development/docker-compose.mysql.yml`
